### PR TITLE
ENH: Fix line width of figures

### DIFF
--- a/tlab_pptx/common.py
+++ b/tlab_pptx/common.py
@@ -120,7 +120,7 @@ def add_figure(
         showlegend=False,
         template="simple_white"
     )
-    fig.update_traces(line=dict(width=0.7))
+    fig.update_traces(line=dict(width=0.85))
     fig.update_xaxes(ticks="inside", mirror=True, showline=True)
     fig.update_yaxes(ticks="inside", mirror=True, showline=True)
     with io.BytesIO(fig.to_image("png", scale=10)) as f:


### PR DESCRIPTION
## Issue Description
The line width was set to 0.7 in PR https://github.com/Waseda-TakeuchiLab/tlab-pptx/pull/2.
However, it is too thin to display a fitting curve with black line.

### Width 0.7
<img src="https://user-images.githubusercontent.com/106423390/178571968-8ad77776-3982-4f8a-9455-b6e0c7f5daf1.png" alt="width=0.7" width=640 ></img>


## Proposal
The value of 0.85 is kind for humans to see the lines.

### Width 0.8
<img src="https://user-images.githubusercontent.com/106423390/178573086-c12013e5-454e-4761-90b9-618122e5cbc9.png" alt="width=0.8" width=640></img>

### Width 0.85
<img src="https://user-images.githubusercontent.com/106423390/178572309-d83e1041-176e-4414-a63c-4cafdd962217.png" alt="width=0.85" width=640></img>

### Width 0.9
<img src="https://user-images.githubusercontent.com/106423390/178573202-5703cbf8-5041-4451-9876-a32e70dc487a.png" alt="width=0.9" width=640></img>

