### PR TITLE
ENH: Specify version of requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-pandas
-plotly
-kaleido
-python-pptx
+pandas>=1.4.3
+plotly>=5.9.0
+kaleido>=0.2.1
+python-pptx>=0.6.21
 
 # For test
 mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = tlab_pptx
+name = tlab-pptx
 version = attr: tlab_pptx.__version__
 author = Shuhei Nitta
 author_email = huisintheta@gmail.com
@@ -16,10 +16,10 @@ include_package_data = True
 packages = find:
 test_suite = tests
 install_requires =
-    pandas
-    plotly
-    kaleido
-    python-pptx
+    pandas>=1.4.3
+    plotly>=5.9.0
+    kaleido>=0.2.1
+    python-pptx>=0.6.21
 
 [options.packages.find]
 exclude = 


### PR DESCRIPTION
Specify version of requirements.

- pandas >= 1.4.3
- plotly >= 5.9.0
- kaleido >= 0.2.1
- python-pptx >= 0.6.21